### PR TITLE
initial work to convert to new etcd operator

### DIFF
--- a/changelog/v3.0.md
+++ b/changelog/v3.0.md
@@ -10,4 +10,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- converted ETCD operator
+- converted ETCD operator, updated reds image

--- a/changelog/v3.0.md
+++ b/changelog/v3.0.md
@@ -11,3 +11,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - converted ETCD operator, updated reds image
+- added this line

--- a/changelog/v3.0.md
+++ b/changelog/v3.0.md
@@ -1,0 +1,13 @@
+# Changelog for v3.0
+
+All notable changes to this project for v3.0.Z will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+
+## [3.0.0] - 2023-01-06
+
+### Changed
+
+- converted ETCD operator

--- a/charts/v3.0/cray-hms-reds/.gitignore
+++ b/charts/v3.0/cray-hms-reds/.gitignore
@@ -1,0 +1,2 @@
+# by default we'll ignore any subcharts included, but simply adjust this if need be
+charts/*

--- a/charts/v3.0/cray-hms-reds/.helmignore
+++ b/charts/v3.0/cray-hms-reds/.helmignore
@@ -1,0 +1,1 @@
+cray-hms-reds*.tgz

--- a/charts/v3.0/cray-hms-reds/Chart.yaml
+++ b/charts/v3.0/cray-hms-reds/Chart.yaml
@@ -9,9 +9,6 @@ dependencies:
   - name: cray-service
     version: "~9.0.0"
     repository: https://artifactory.algol60.net/artifactory/csm-helm-charts
-  - name: cray-etcd-base
-    version: "~1.0.0"
-    repository: https://artifactory.algol60.net/artifactory/csm-helm-charts
 maintainers:
   - name: Hardware Management
     url: https://github.com/orgs/Cray-HPE/teams/hardware-management

--- a/charts/v3.0/cray-hms-reds/Chart.yaml
+++ b/charts/v3.0/cray-hms-reds/Chart.yaml
@@ -1,0 +1,20 @@
+apiVersion: v2
+name: "cray-hms-reds"
+version: 3.0.0
+description: "Kubernetes resources for cray-hms-reds"
+home: "https://github.com/Cray-HPE/hms-reds-charts"
+sources:
+  - "https://github.com/Cray-HPE/hms-reds"
+dependencies:
+  - name: cray-service
+    version: "~9.0.0"
+    repository: https://artifactory.algol60.net/artifactory/csm-helm-charts
+  - name: cray-etcd-base
+    version: "~1.0.0"
+    repository: https://artifactory.algol60.net/artifactory/csm-helm-charts
+maintainers:
+  - name: Hardware Management
+    url: https://github.com/orgs/Cray-HPE/teams/hardware-management
+appVersion: "1.24.0"
+annotations:
+  artifacthub.io/license: "MIT"

--- a/charts/v3.0/cray-hms-reds/Chart.yaml
+++ b/charts/v3.0/cray-hms-reds/Chart.yaml
@@ -15,6 +15,6 @@ dependencies:
 maintainers:
   - name: Hardware Management
     url: https://github.com/orgs/Cray-HPE/teams/hardware-management
-appVersion: "1.24.0"
+appVersion: "2.0.0"
 annotations:
   artifacthub.io/license: "MIT"

--- a/charts/v3.0/cray-hms-reds/templates/configmaps.yaml
+++ b/charts/v3.0/cray-hms-reds/templates/configmaps.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: reds-cacert-info
+data:
+  CA_URI: "{{ .Values.hms_ca_uri }}"
+

--- a/charts/v3.0/cray-hms-reds/templates/hook-serviceaccount.yaml
+++ b/charts/v3.0/cray-hms-reds/templates/hook-serviceaccount.yaml
@@ -1,0 +1,41 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cray-reds-service-account
+  namespace: services
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade,pre-rollback
+    "helm.sh/hook-delete-policy": before-hook-creation
+    "helm.sh/hook-weight": "-5"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: cray-reds-service-account
+  namespace: services
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade,pre-rollback
+    "helm.sh/hook-delete-policy": before-hook-creation
+    "helm.sh/hook-weight": "-5"
+rules:
+- apiGroups: ["batch"]
+  resources: ["jobs"]
+  verbs: ["create", "delete", "get", "list", "patch", "update", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: cray-reds-service-account
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade,pre-rollback
+    "helm.sh/hook-delete-policy": before-hook-creation
+    "helm.sh/hook-weight": "-5"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: cray-reds-service-account
+subjects:
+  - kind: ServiceAccount
+    name: cray-reds-service-account
+    namespace: services

--- a/charts/v3.0/cray-hms-reds/templates/jobs.yaml
+++ b/charts/v3.0/cray-hms-reds/templates/jobs.yaml
@@ -1,0 +1,59 @@
+---
+apiVersion: batch/v1
+kind:       Job
+metadata:
+  name: cray-reds-vault-loader
+spec:
+  template:
+    spec:
+      restartPolicy: OnFailure
+      serviceAccountName: "jobs-watcher"
+      containers:
+        - name: cray-reds-vault-loader
+          env:
+            - name: VAULT_ADDR
+              value: "http://cray-vault.vault:8200"
+            - name: VAULT_SKIP_VERIFY
+              value: "true"
+            - name: VAULT_REDFISH_BMC_DEFAULTS
+              valueFrom:
+                secretKeyRef:
+                  name: cray-reds-credentials
+                  key: vault_redfish_defaults
+            - name: VAULT_REDFISH_SWITCH_DEFAULTS
+              valueFrom:
+                secretKeyRef:
+                  name: cray-reds-credentials
+                  key: vault_switch_defaults
+          image: {{ .Values.image.repository }}:{{ .Values.global.appVersion }}
+          command: ["vault_loader"]
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: cray-reds-deleter
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade,pre-rollback
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    "helm.sh/hook-weight": "0"
+spec:
+  template:
+    metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
+    spec:
+      restartPolicy: OnFailure
+      serviceAccountName: "cray-reds-service-account"
+      containers:
+        - name: job-deleter
+          image: "{{ .Values.kubectl.image.repository }}:{{ .Values.kubectl.image.tag }}"
+          imagePullPolicy: "{{ .Values.kubectl.image.pullPolicy }}"
+          command:
+          - /bin/sh
+          - -c
+          - set -x;
+            echo " Deleteing job cray-reds-vault-loader";
+            kubectl -n services delete job cray-reds-vault-loader;
+            echo " Deleteing job cray-reds-init";
+            kubectl -n services delete job cray-reds-init;
+            exit 0

--- a/charts/v3.0/cray-hms-reds/templates/rbac.yaml
+++ b/charts/v3.0/cray-hms-reds/templates/rbac.yaml
@@ -1,0 +1,32 @@
+## jobs-watcher service account is a generic sa useful for InitContainers that
+## want to watch for state of Job and wait until the job is completed
+## jobs-watcher service account is available in "services" namespace
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: cray-reds-init-crb
+subjects:
+- kind: ServiceAccount
+  name: cray-reds-init
+  namespace: services
+roleRef:
+  kind: ClusterRole
+  name: cray-reds-init-role
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  namespace: services
+  name: cray-reds-init
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: cray-reds-init-role
+rules:
+- apiGroups: [""]
+  resources: ["configmaps", "services"]
+  resourceNames: ["reds-init-configmap", "api-gateway", "istio-ingressgateway"]
+  verbs: ["update", "get", "patch"]

--- a/charts/v3.0/cray-hms-reds/templates/tests/test-smoke.yaml
+++ b/charts/v3.0/cray-hms-reds/templates/tests/test-smoke.yaml
@@ -1,0 +1,36 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: "{{ .Release.Name }}-test-smoke"
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    "helm.sh/hook-weight": "-1" #run this first!
+
+  labels:
+    app.kubernetes.io/name: "{{ .Release.Name }}-test-smoke"
+
+spec:
+  backoffLimit: 0
+  template:
+    metadata:
+      name: "{{ .Release.Name }}-test-smoke"
+      annotations:
+        "proxy.istio.io/config": '{ "holdApplicationUntilProxyStarts": true }'
+      labels:
+        app.kubernetes.io/managed-by:  "{{ include "cray-service.name" . }}"
+        app.kubernetes.io/instance:  "{{ .Release.Name }}-test-smoke"
+        helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    spec:
+      restartPolicy: Never
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+        runAsGroup: 65534
+      containers:
+        - name: "smoke"
+          image: "{{ .Values.tests.image.repository }}:{{ .Values.global.testVersion }}"
+          imagePullPolicy: "{{ .Values.tests.image.pullPolicy }}"
+          command: ["/bin/sh", "-c"]
+          args: [ "entrypoint.sh smoke -f smoke.json -u http://cray-reds"]

--- a/charts/v3.0/cray-hms-reds/values.yaml
+++ b/charts/v3.0/cray-hms-reds/values.yaml
@@ -1,0 +1,108 @@
+# Please refer to https://stash.us.cray.com/projects/CLOUD/repos/cray-charts/browse/stable/cray-service/values.yaml?at=refs%2Fheads%2Fmaster
+# for more info on values you can set/override
+# Note that cray-service.containers[*].image and cray-service.initContainers[*].image map values are one of the only structures that
+# differ from the standard kubernetes container spec:
+# image:
+#   repository: ""
+#   tag: "" (default = "latest")
+#   pullPolicy: "" (default = "IfNotPresent")
+
+global:
+  appVersion: 1.24.0
+  testVersion: 1.24.0
+
+image:
+  repository: artifactory.algol60.net/csm-docker/stable/cray-reds
+  pullPolicy: IfNotPresent
+
+tests:
+  image:
+    repository: artifactory.algol60.net/csm-docker/stable/cray-reds-test
+    pullPolicy: IfNotPresent
+
+# Version of the kubectl pod to use when upgrading/downgrading charts
+kubectl:
+  image:
+    repository: artifactory.algol60.net/csm-docker/stable/docker-kubectl
+    tag: 1.19.15
+    pullPolicy: IfNotPresent
+
+hms_ca_uri: ""
+
+cray-etcd-base:
+  nameOverride: "cray-reds"
+  fullnameOverride: "cray-reds"
+  etcd:
+    enabled: true
+    fullnameOverride: "cray-reds-etcd"
+    nameOverride: "cray-reds-etcd"
+
+cray-service:
+  type: "Deployment"
+  nameOverride: "cray-reds"
+  fullnameOverride: "cray-reds"
+  serviceAccountName: "jobs-watcher"
+  etcdWaitContainer: true
+  containers:
+    cray-reds:
+      name: "cray-reds"
+      image:
+        repository: artifactory.algol60.net/csm-docker/stable/cray-reds
+      env:
+        - name: ETCD_HOST
+          value: cray-reds-etcd-client
+        - name: ETCD_PORT
+          value: "2379"
+        - name: DATASTORE_URL
+          value: $(ETCD_HOST):$(ETCD_PORT)
+        - name: HSM_URL
+          value: http://cray-smd/hsm/v2
+        - name: REDS_BYPASS_SWITCH_BLACKLIST_PANIC
+          value: ""
+        - name: VAULT_ADDR
+          value: "http://cray-vault.vault:8200"
+        - name: VAULT_SKIP_VERIFY
+          value: "true"
+        - name: SLS_ADDR
+          value: "cray-sls/v1"
+        - name: REDS_SYSLOG_TARG
+          value: "rsyslog-aggregator.hmnlb:514"
+        - name: REDS_NTP_TARG
+          valueFrom:
+            configMapKeyRef:
+              name: meds-nwproto-info
+              key: NTP_HOST
+        - name: REDS_CA_URI
+          valueFrom:
+            configMapKeyRef:
+              name: reds-cacert-info
+              key: CA_URI
+      readinessProbe:
+        httpGet:
+          port: 8269
+          path: /v1/readiness
+        initialDelaySeconds: 15
+        periodSeconds: 30
+      livenessProbe:
+        httpGet:
+          port: 8269
+          path: /v1/liveness
+        initialDelaySeconds: 5
+        periodSeconds: 10
+      command: ["/bin/sh", "-c"]
+      args: ["until curl --head localhost:15000 ; do echo Waiting for Sidecar; sleep 3 ; done ; echo Sidecar available; reds $REDS_OPTS $( [ -n \"$HSM_URL\" ] && echo --hsm=$HSM_URL ) --datastore=$DATASTORE_URL -syslog \"$REDS_SYSLOG_TARG\" -ntp \"$REDS_NTP_TARG\" -sls \"$SLS_ADDR\""]
+      ports:
+        - name: http
+          containerPort: 8269
+      volumeMounts:
+        - name: cray-pki-cacert-vol
+          mountPath: /usr/local/cray-pki
+  volumes:
+    cray-pki-cacert-vol:
+      name: cray-pki-cacert-vol
+      configMap:
+        name: cray-configmap-ca-public-key
+  ingress:
+    enabled: true
+    prefix: "/apis/reds/"
+    uri: "/"

--- a/charts/v3.0/cray-hms-reds/values.yaml
+++ b/charts/v3.0/cray-hms-reds/values.yaml
@@ -8,8 +8,8 @@
 #   pullPolicy: "" (default = "IfNotPresent")
 
 global:
-  appVersion: 1.24.0
-  testVersion: 1.24.0
+  appVersion: 2.0.0
+  testVersion: 2.0.0
 
 image:
   repository: artifactory.algol60.net/csm-docker/stable/cray-reds
@@ -29,49 +29,27 @@ kubectl:
 
 hms_ca_uri: ""
 
-cray-etcd-base:
-  nameOverride: "cray-reds"
-  fullnameOverride: "cray-reds"
-  etcd:
-    enabled: true
-    fullnameOverride: "cray-reds-etcd"
-    nameOverride: "cray-reds-etcd"
 
 cray-service:
   type: "Deployment"
   nameOverride: "cray-reds"
   fullnameOverride: "cray-reds"
   serviceAccountName: "jobs-watcher"
-  etcdWaitContainer: true
   containers:
     cray-reds:
       name: "cray-reds"
       image:
         repository: artifactory.algol60.net/csm-docker/stable/cray-reds
       env:
-#        - name: ETCD_HOST
-#          value: cray-reds-etcd-client
-#        - name: ETCD_PORT
-#          value: "2379"
-        - name: DATASTORE_URL
-          value: $(ETCD_HOST):$(ETCD_PORT)
         - name: HSM_URL
           value: http://cray-smd/hsm/v2
-        - name: REDS_BYPASS_SWITCH_BLACKLIST_PANIC
-          value: ""
+
         - name: VAULT_ADDR
           value: "http://cray-vault.vault:8200"
         - name: VAULT_SKIP_VERIFY
           value: "true"
         - name: SLS_ADDR
           value: "cray-sls/v1"
-        - name: REDS_SYSLOG_TARG
-          value: "rsyslog-aggregator.hmnlb:514"
-        - name: REDS_NTP_TARG
-          valueFrom:
-            configMapKeyRef:
-              name: meds-nwproto-info
-              key: NTP_HOST
         - name: REDS_CA_URI
           valueFrom:
             configMapKeyRef:
@@ -90,7 +68,7 @@ cray-service:
         initialDelaySeconds: 5
         periodSeconds: 10
       command: ["/bin/sh", "-c"]
-      args: ["until curl --head localhost:15000 ; do echo Waiting for Sidecar; sleep 3 ; done ; echo Sidecar available; reds $REDS_OPTS $( [ -n \"$HSM_URL\" ] && echo --hsm=$HSM_URL ) --datastore=$DATASTORE_URL -syslog \"$REDS_SYSLOG_TARG\" -ntp \"$REDS_NTP_TARG\" -sls \"$SLS_ADDR\""]
+      args: ["until curl --head localhost:15000 ; do echo Waiting for Sidecar; sleep 3 ; done ; echo Sidecar available; reds $REDS_OPTS $( [ -n \"$HSM_URL\" ] && echo --hsm=$HSM_URL ) -sls \"$SLS_ADDR\""]
       ports:
         - name: http
           containerPort: 8269

--- a/charts/v3.0/cray-hms-reds/values.yaml
+++ b/charts/v3.0/cray-hms-reds/values.yaml
@@ -49,10 +49,10 @@ cray-service:
       image:
         repository: artifactory.algol60.net/csm-docker/stable/cray-reds
       env:
-        - name: ETCD_HOST
-          value: cray-reds-etcd-client
-        - name: ETCD_PORT
-          value: "2379"
+#        - name: ETCD_HOST
+#          value: cray-reds-etcd-client
+#        - name: ETCD_PORT
+#          value: "2379"
         - name: DATASTORE_URL
           value: $(ETCD_HOST):$(ETCD_PORT)
         - name: HSM_URL

--- a/cray-hms-reds.compatibility.yaml
+++ b/cray-hms-reds.compatibility.yaml
@@ -4,6 +4,7 @@ chartVersionToCSMVersion:
   # Chart version: CSM version
   ">=2.0.0": "~1.2.0" # Chart Version: 2.0.0 <= x.y.z, CSM Version: 1.2.0 <= x.y.z < 1.3.0
   ">=2.1.0": "~1.3.0"
+  ">=3.0.0": "~1.6.0"
 
 # The application version must be compliant to semantic versioning. 
 # If the application makes a backwards incompatible change, then its major version needs to be increment.
@@ -15,6 +16,7 @@ chartVersionToApplicationVersion:
   "2.1.1": "1.22.0"
   "2.1.2": "1.23.0"
   "2.1.3": "1.24.0"
+  "3.0.0": "1.24.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.  
 chartValidationLog: []

--- a/cray-hms-reds.compatibility.yaml
+++ b/cray-hms-reds.compatibility.yaml
@@ -16,7 +16,7 @@ chartVersionToApplicationVersion:
   "2.1.1": "1.22.0"
   "2.1.2": "1.23.0"
   "2.1.3": "1.24.0"
-  "3.0.0": "1.24.0"
+  "3.0.0": "2.0.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.  
 chartValidationLog: []


### PR DESCRIPTION
## Summary and Scope

Removed the ETC containers, no longer needed.

## Issues and Related PRs


* Resolves CASMHMS-5872
## Testing

_List the environments in which these changes were tested._

Tested on:

  * `Mug`
  * Local development environment
  * Virtual Shasta

Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? Yes
- Were continuous integration tests run? If not, why? Yes
- Was upgrade tested? If not, why? Yes, it works.
- Was downgrade tested? If not, why? Yes, downgrades to the 2.X series from the 3.0 series of charts do not work.  

The following test cases were performed:
- delete master 1 component from HSM and see that it come back after REDS restart
- delete redfish endpoint for some other management NCN and see that it comes back after REDS restart
- for a leaf switch: go into vault, remove leaf switch creds, then validate that they get added back
purge a rosetta from HSM and validate that it gets rediscovered, (by the discovery job).

All test cases were successful. Here are logs and type script from testing:
 
Type script: [reds_testing.log](https://github.com/Cray-HPE/hms-reds-charts/files/10376866/reds_testing.log)
Pod logs:
- [reds_pod.1.log](https://github.com/Cray-HPE/hms-reds-charts/files/10376873/reds_pod.1.log)
- [reds_pod.2.log](https://github.com/Cray-HPE/hms-reds-charts/files/10376874/reds_pod.2.log)
- [reds_pod.3.log](https://github.com/Cray-HPE/hms-reds-charts/files/10376875/reds_pod.3.log)


## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_
 Yes, downgrades to the 2.X series from the 3.0 series of charts do not work.  If a downgrade is required the cray-hms-reds chart needs to be uninstalled, and the 2.X chart needs to be installed. However, the upgrade from 2.Y.Z to 3.Y.Z runs without issues.
```
root@ncn-m001 2023-01-09 19:56:34 ~/anieuwsma # helm -n services rollback cray-hms-reds 1
Error: cannot patch "cray-reds" with kind Deployment: The order in patch list:
[map[name:ETCD_HOST value:cray-reds-etcd-client] map[name:ETCD_HOST value:cray-reds-etcd-client] map[name:ETCD_PORT value:2379] map[name:ETCD_PORT value:2379] map[name:DATASTORE_URL value:$(ETCD_HOST):$(ETCD_PORT)] map[name:REDS_BYPASS_SWITCH_BLACKLIST_PANIC value:] map[name:REDS_SYSLOG_TARG value:rsyslog-aggregator.hmnlb:514] map[name:REDS_NTP_TARG valueFrom:map[configMapKeyRef:map[key:NTP_HOST name:meds-nwproto-info]]]]
 doesn't match $setElementOrder list:
[map[name:ETCD_HOST] map[name:ETCD_PORT] map[name:ETCD_HOST] map[name:ETCD_PORT] map[name:DATASTORE_URL] map[name:HSM_URL] map[name:REDS_BYPASS_SWITCH_BLACKLIST_PANIC] map[name:VAULT_ADDR] map[name:VAULT_SKIP_VERIFY] map[name:SLS_ADDR] map[name:REDS_SYSLOG_TARG] map[name:REDS_NTP_TARG] map[name:REDS_CA_URI]]
```

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable