### PR TITLE
Add SNMP credentials to vault for MgmtHLSwitch and CDUMgmtSwitch types

### DIFF
--- a/changelog/v3.0.md
+++ b/changelog/v3.0.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [3.0.1] - 2023-05-09
+
+### Changed
+
+- Add SNMP credentials to vault for MgmtHLSwitch and CDUMgmtSwitch types.
+
 ## [3.0.0] - 2023-01-06
 
 ### Changed

--- a/charts/v3.0/cray-hms-reds/Chart.yaml
+++ b/charts/v3.0/cray-hms-reds/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: "cray-hms-reds"
-version: 3.0.0
+version: 3.0.1
 description: "Kubernetes resources for cray-hms-reds"
 home: "https://github.com/Cray-HPE/hms-reds-charts"
 sources:
@@ -12,6 +12,6 @@ dependencies:
 maintainers:
   - name: Hardware Management
     url: https://github.com/orgs/Cray-HPE/teams/hardware-management
-appVersion: "2.0.0"
+appVersion: "2.1.0"
 annotations:
   artifacthub.io/license: "MIT"

--- a/charts/v3.0/cray-hms-reds/values.yaml
+++ b/charts/v3.0/cray-hms-reds/values.yaml
@@ -8,8 +8,8 @@
 #   pullPolicy: "" (default = "IfNotPresent")
 
 global:
-  appVersion: 2.0.0
-  testVersion: 2.0.0
+  appVersion: 2.1.0
+  testVersion: 2.1.0
 
 image:
   repository: artifactory.algol60.net/csm-docker/stable/cray-reds

--- a/cray-hms-reds.compatibility.yaml
+++ b/cray-hms-reds.compatibility.yaml
@@ -17,6 +17,7 @@ chartVersionToApplicationVersion:
   "2.1.2": "1.23.0"
   "2.1.3": "1.24.0"
   "3.0.0": "2.0.0"
+  "3.0.1": "2.1.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.  
 chartValidationLog: []


### PR DESCRIPTION
## Summary and Scope

Update the REDS image version for CASMHMS-5991 - Add SNMP creds for MgmtHLSwitch and CDUMgmtSwitch types to vault

## Issues and Related PRs

* Resolves [CASMHMS-5991](https://jira-pro.its.hpecorp.net:8443/browse/CASMHMS-5991)

## Testing

For testing, see https://github.com/Cray-HPE/hms-reds/pull/37


## Risks and Mitigations

low


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable